### PR TITLE
[MRG] DOC: clarify table of contents in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jonescompneurolab/hnn-workshop-materials/HEAD)
+
 # HNN workshop materials
 
-* Tutorials with HNN-core
- * Compliments the [HNN-GUI tutorials](https://hnn.brown.edu/tutorials/)
- * [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/jonescompneurolab/hnn-workshop-materials/HEAD)
+Here we provide HNN-core notebooks that compliment the following
+[HNN-GUI tutorials](https://hnn.brown.edu/tutorials/):
+ * Alpha/Beta tutorial
+ * ERP tutorial


### PR DESCRIPTION
I was testing out the binder link and realized that our README.md was a little unclear on what exactly this repo contains, so this is a very minor adjustment that hopefully clarifies things in case we have to direct workshop participants here.